### PR TITLE
Delay special init to make start_lp visible

### DIFF
--- a/gframe/single_duel.cpp
+++ b/gframe/single_duel.cpp
@@ -554,11 +554,11 @@ void SingleDuel::TPResult(DuelPlayer* dp, unsigned char tp) {
 	set_card_reader(DataManager::CardReader);
 	set_message_handler(SingleDuel::MessageHandler);
 	pduel = create_duel(duel_seed);
+	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
+	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 #ifdef YGOPRO_SERVER_MODE
 	preload_script(pduel, "./script/special.lua", 0);
 #endif
-	set_player_info(pduel, 0, host_info.start_lp, host_info.start_hand, host_info.draw_count);
-	set_player_info(pduel, 1, host_info.start_lp, host_info.start_hand, host_info.draw_count);
 	int opt = (int)host_info.duel_rule << 16;
 	if(host_info.no_shuffle_deck)
 		opt |= DUEL_PSEUDO_SHUFFLE;


### PR DESCRIPTION
Fix `Duel.GetLP()` always return 8000 in `special.lua`