### PR TITLE
fix parse param

### DIFF
--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -84,12 +84,13 @@ int main(int argc, char* argv[]) {
 	ygo::game_info.time_limit = 180;
 	std::memset(ygo::pre_seed, 0, sizeof(ygo::pre_seed));
 	std::memset(ygo::pre_seed_specified, 0, sizeof(ygo::pre_seed_specified));
-	if (argc > 1) {
+	if (argc > 1 && argc < 13) {
+		std::fprintf(stderr, "Bad param count. Please refer to readme, or don't use any param to quick test.\n");
+		return 1;
+	}
+	else if (argc >= 13) {
 		ygo::server_port = atoi(argv[1]);
-		int lflist = atoi(argv[2]);
-		if(lflist < 0)
-			lflist = 999;
-		ygo::game_info.lflist = lflist;
+		ygo::game_info.lflist = atoi(argv[2]);
 		ygo::game_info.rule = atoi(argv[3]);
 		int mode = atoi(argv[4]);
 		if(mode > 2)

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -33,7 +33,8 @@ int main(int argc, char* argv[]) {
 #else
 	std::setlocale(LC_CTYPE, "");
 #endif
-#if defined __APPLE__ && !defined YGOPRO_SERVER_MODE
+#ifndef YGOPRO_SERVER_MODE
+#ifdef __APPLE__
 	CFURLRef bundle_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
 	CFURLRef bundle_base_url = CFURLCreateCopyDeletingLastPathComponent(nullptr, bundle_url);
 	CFStringRef bundle_ext = CFURLCopyPathExtension(bundle_url);
@@ -59,6 +60,7 @@ int main(int argc, char* argv[]) {
 		}
 	}
 #endif //_WIN32
+#endif //YGOPRO_SERVER_MODE
 #ifdef _WIN32
 	WORD wVersionRequested;
 	WSADATA wsaData;

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -33,29 +33,16 @@ void NetServer::InitDuel()
 		duel_mode->etimer = event_new(net_evbase, 0, EV_TIMEOUT | EV_PERSIST, TagDuel::TagTimer, duel_mode);
 	}
 
-	CTOS_CreateGame* pkt = new CTOS_CreateGame;
-	
-	pkt->info.mode = game_info.mode;
-	pkt->info.start_hand = game_info.start_hand;
-	pkt->info.start_lp = game_info.start_lp;
-	pkt->info.draw_count = game_info.draw_count;
-	pkt->info.no_check_deck = game_info.no_check_deck;
-	pkt->info.no_shuffle_deck = game_info.no_shuffle_deck;
-	pkt->info.duel_rule = game_info.duel_rule;
-	pkt->info.rule = game_info.rule;
-	pkt->info.time_limit = game_info.time_limit;
+	duel_mode->host_info = game_info;
 
-	if(game_info.lflist == 999)
-		pkt->info.lflist = 0;
-	else if(game_info.lflist >= deckManager._lfList.size())
-		pkt->info.lflist = deckManager._lfList[0].hash;
-	else
-		pkt->info.lflist = deckManager._lfList[game_info.lflist].hash;
-	
-	duel_mode->host_info = pkt->info;
-	
-	BufferIO::CopyWStr(pkt->name, duel_mode->name, 20);
-	BufferIO::CopyWStr(pkt->pass, duel_mode->pass, 20);
+	int32_t lflistIndex = (int32_t)game_info.lflist;
+	if(lflistIndex < 0) {
+		duel_mode->host_info.lflist = 0;
+	} else {
+		if(lflistIndex >= deckManager._lfList.size())
+			lflistIndex = 0;
+		duel_mode->host_info.lflist = deckManager._lfList[lflistIndex].hash;
+	}
 }
 
 bool NetServer::IsCanIncreaseTime(unsigned short gameMsg, void *pdata, unsigned int len) {


### PR DESCRIPTION
`YGOPRO_SERVER_MODE` 下：
- Windows 上不再检查打开文件的命令行参数
- 检查命令行参数的数量，避免超出下标
- lflist = 999不再是无禁卡表的守卫值，改用负数
- 默认用补码转换有符号的负数参数为无符号的HostInfo.lflist并转换回来（虽然不是标准但是是实现定义行为）
- 直接复制HostInfo结构体
- 不再读写无用的duel_mode->name等
